### PR TITLE
Round up for Engine/Gyro weights

### DIFF
--- a/source/Engine/Engine.cs
+++ b/source/Engine/Engine.cs
@@ -32,10 +32,10 @@ namespace MechEngineer
             => Mathf.Min(FreeExternalHeatSinkCount, CoreDef.MaxFreeExternalHeatSinks)
             * CoreRef.HeatSinkDef.Def.Tonnage;
 
-        internal float GyroTonnage => (CoreDef.StandardGyroTonnage * Weights.GyroFactor).RoundStandard();
+        internal float GyroTonnage => (CoreDef.StandardGyroTonnage * Weights.GyroFactor).RoundUp();
 
-        internal float EngineTonnage => (CoreDef.StandardEngineTonnage * Weights.EngineFactor).RoundStandard();
- 
+        internal float EngineTonnage => (CoreDef.StandardEngineTonnage * Weights.EngineFactor).RoundUp();
+
         internal float HeatSinkTonnage => CoreRef.InternalHeatSinkTonnage - FreeExternalHeatSinkTonnage;
 
         internal float TotalTonnage => HeatSinkTonnage + EngineTonnage + GyroTonnage;

--- a/source/Misc/Extensions.cs
+++ b/source/Misc/Extensions.cs
@@ -25,6 +25,16 @@ namespace MechEngineer
             return Mathf.Round(@this * 2f) / 2f;
         }
 
+        internal static float RoundUp(this float @this)
+        {
+            if (Control.settings.FractionalAccounting)
+            {
+                return Math.Ceiling(@this * 1000f) / 1000f;
+            }
+
+            return Math.Ceiling(@this * 2f) / 2f;
+        }
+
         internal static float RoundBy5(this float @this)
         {
             return Mathf.Round(@this / 5) * 5;


### PR DESCRIPTION
Mathf.Round defaults to "round-to-even", meaning that Mathf.Round(12.5)
=> 12 instead of 13.  This causes issues with various LT and XL engine
weights being underweight by half a ton (e.g. the LT235 and XL250),
since they should be rounded up by default.  Battletech does not round
in the player's favor.

There may be similar, unresolved issues with endosteel structure savings
-- this warrants further investigation.

#116 